### PR TITLE
fix: remove python=3.14

### DIFF
--- a/news/python-version.rst
+++ b/news/python-version.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No news added: Remove python::3.14 in the ``pyproject.toml``.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
         'Operating System :: Unix',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Scientific/Engineering :: Chemistry',
 ]


### PR DESCRIPTION
### Problem

<!--
For a bug report, please copy and paste any error messages from the application or command-line here.
For a feature request, please state how the new functionality could benefit the community.
-->

Closes #8

### Proposed solution

Remove "'Programming Language :: Python :: 3.14'," in the `pyproject.toml`.
