### PR TITLE
feat: add `pdfbl-cli run <input.dp-in>` to run DiffpyInterpreter with the input file

### DIFF
--- a/news/add-cli.rst
+++ b/news/add-cli.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add CLI interface to run DSL input file
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-pdfbl-cli = "pdfbl.sequential.pdfbl_sequential_app:main"
+pdfbl = "pdfbl.sequential.pdfbl_sequential_app:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [project.scripts]
-pdfbl-sequential = "pdfbl.sequential.pdfbl_sequential_app:main"
+pdfbl-cli = "pdfbl.sequential.pdfbl_sequential_app:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements/pip.txt"]}

--- a/src/pdfbl/sequential/diffpy_interpreter.py
+++ b/src/pdfbl/sequential/diffpy_interpreter.py
@@ -31,7 +31,7 @@ CreateCommand:
 ;
 
 SaveCommand:
-    'save to' source=STRING
+    'save' 'to' source=STRING
 ;
 
 VariableBlock:
@@ -188,7 +188,7 @@ class DiffpyInterpreter:
         dpin_path = Path(args.input_file)
         if not dpin_path.exists():
             raise FileNotFoundError(
-                f"{str(dpin_path)} not Found. Please check if this file "
+                f"{str(dpin_path)} not found. Please check if this file "
                 "exists and provide the correct path to it."
             )
         dsl_code = dpin_path.read_text()

--- a/src/pdfbl/sequential/diffpy_interpreter.py
+++ b/src/pdfbl/sequential/diffpy_interpreter.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import yaml
@@ -13,7 +14,7 @@ Program:
 ;
 
 Command:
-    LoadCommand | SetCommand | CreateCommand
+    LoadCommand | SetCommand | CreateCommand | SaveCommand
 ;
 
 LoadCommand:
@@ -27,6 +28,10 @@ SetCommand:
 
 CreateCommand:
     'create' 'equation' 'variables' value+=Value[eolterm]
+;
+
+SaveCommand:
+    'save to' source=STRING
 ;
 
 VariableBlock:
@@ -53,6 +58,7 @@ class DiffpyInterpreter:
                 "LoadCommand": self.load_command_processor,
                 "VariableBlock": self.variable_block_processor,
                 "CreateCommand": self.create_command_processor,
+                "SaveCommand": self.save_command_processor,
             }
         )
         self.inputs = {}
@@ -136,6 +142,9 @@ class DiffpyInterpreter:
             v for v in command.value if isinstance(v, str)
         ]
 
+    def save_command_processor(self, command):
+        self.inputs["result_path"] = command.source
+
     def configure_adapter(self):
         self.pdfadapter.initialize_profile(
             self.inputs["profile_path"], **self.inputs["profiles_config"]
@@ -170,7 +179,22 @@ class DiffpyInterpreter:
             least_squares(
                 self.pdfadapter.recipe.residual, self.pdfadapter.recipe.values
             )
+        if "result_path" in self.inputs:
+            with open(self.inputs["result_path"], "w") as f:
+                json.dump(self.pdfadapter.get_results(), f, indent=4)
         return self.pdfadapter.get_results()
+
+    def run_app(self, args):
+        dpin_path = Path(args.input_file)
+        if not dpin_path.exists():
+            raise FileNotFoundError(
+                f"{str(dpin_path)} not Found. Please check if this file "
+                "exists and provide the correct path to it."
+            )
+        dsl_code = dpin_path.read_text()
+        self.interpret(dsl_code)
+        self.configure_adapter()
+        self.run()
 
 
 if __name__ == "__main__":
@@ -184,13 +208,14 @@ set exp_ni q_range as 0.1 25
 set exp_ni calculation_range as 1.5 50 0.01
 create equation variables s0
 set equation as "s0*G1"
+save to "results.json"
 
 variables:
 ---
-- G1_a: 3.52
+- G1.a: 3.52
 - s0: 0.4
-- G1_Uiso_0: 0.005
-- G1_delta2: 2
+- G1.Uiso_0: 0.005
+- G1.delta2: 2
 - qdamp: 0.04
 - qbroad: 0.02
 ---

--- a/src/pdfbl/sequential/pdfbl_sequential_app.py
+++ b/src/pdfbl/sequential/pdfbl_sequential_app.py
@@ -1,6 +1,7 @@
 import argparse
 
 from pdfbl.sequential import __version__
+from pdfbl.sequential.diffpy_interpreter import DiffpyInterpreter
 
 
 def main():
@@ -22,4 +23,10 @@ def main():
         version=f"pdfbl.sequential {__version__}",
         help="Show the version of pdfbl.sequential and exit.",
     )
-    parser.parse_args()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("input_file", help="Input .dp-in file.")
+    run_parser.set_defaults(func=DiffpyInterpreter().run_app)
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)

--- a/src/pdfbl/sequential/pdfbl_sequential_app.py
+++ b/src/pdfbl/sequential/pdfbl_sequential_app.py
@@ -1,6 +1,7 @@
 import argparse
 
 from pdfbl.sequential import __version__
+from pdfbl.sequential.diffpy_interpreter import DiffpyInterpreter
 
 
 def main():
@@ -9,6 +10,7 @@ def main():
     Examples
     --------
     >>> pdfbl-cli --version
+    >>> pdfbl-cli run input.dp-in
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -22,4 +24,10 @@ def main():
         version=f"pdfbl.sequential {__version__}",
         help="Show the version of pdfbl.sequential and exit.",
     )
-    parser.parse_args()
+    subparsers = parser.add_subparsers(dest="subcommand")
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("input_file", help="Input .dp-in file.")
+    run_parser.set_defaults(func=DiffpyInterpreter().run_app)
+    args = parser.parse_args()
+    if hasattr(args, "func"):
+        args.func(args)

--- a/src/pdfbl/sequential/pdfbl_sequential_app.py
+++ b/src/pdfbl/sequential/pdfbl_sequential_app.py
@@ -9,8 +9,8 @@ def main():
 
     Examples
     --------
-    >>> pdfbl-cli --version
-    >>> pdfbl-cli run input.dp-in
+    >>> pdfbl --version
+    >>> pdfbl run input.dp-in
     """
     parser = argparse.ArgumentParser(
         description=(
@@ -21,8 +21,8 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version=f"pdfbl.sequential {__version__}",
-        help="Show the version of pdfbl.sequential and exit.",
+        version=f"pdfbl {__version__}",
+        help="Show the version of pdfbl and exit.",
     )
     subparsers = parser.add_subparsers(dest="subcommand")
     run_parser = subparsers.add_parser("run")

--- a/src/pdfbl/sequential/pdfbl_sequential_app.py
+++ b/src/pdfbl/sequential/pdfbl_sequential_app.py
@@ -31,3 +31,6 @@ def main():
     args = parser.parse_args()
     if hasattr(args, "func"):
         args.func(args)
+    else:
+        parser.print_help()
+        parser.exit()


### PR DESCRIPTION
### What problem does this PR address?

<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->

The command `pdfbl-cli` will be used by `diffpy.xpdfsuite` internally to parse the diffpy DSL.

Run
```sh
pdfbl-cli run input.dp-in
```
with  `input.dp-in`:
```
load structure ni from "Ni.cif"
load profile exp_ni from "Ni.gr"
set ni spacegroup as auto
set exp_ni q_range as 0.1 25
set exp_ni calculation_range as 1.5 50 0.01
create equation variables s0
set equation as "s0*ni"
save to "results.json"

variables:
---
- ni.a: 3.52
- s0: 0.4
- ni.Uiso_0: 0.005
- ni.delta2: 2
- qdamp: 0.04
- qbroad: 0.02
---
```
to fit examples from `pdfttp_data` chapter 3.


Gives result.json:
```json
{
    "residual": 10.5785294311194,
    "contributions": 10.5785294311194,
    "restraints": 0,
    "chi2": 10.5785294311194,
    "reduced_chi2": 0.0021833910074549844,
    "rw": 0.0294296979105983,
    ...
}
```


### What should the reviewer(s) do?

<!-- Merge the code, provide feedback, initiate a discussion, etc. -->

<!--
Use the following checklist items when applicable (select only what applies):
- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [ ] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
-->